### PR TITLE
Fix path parsing bug in CMD script

### DIFF
--- a/WinRegFavAdd.cmd
+++ b/WinRegFavAdd.cmd
@@ -31,9 +31,12 @@ if not defined DATA_FILE (
 )
 
 :: Process each line in the data file
-for /f "tokens=2 delims=|" %%a in ('type "%DATA_FILE%" ^| findstr /r "^[^#]"') do (
+:: Only process table rows starting with a pipe character. Trim the
+:: surrounding spaces and backticks from the extracted path.
+for /f "tokens=2 delims=|" %%a in ('type "%DATA_FILE%" ^| findstr /r "^|"') do (
     set "PATH=%%a"
     set "PATH=!PATH:~1,-1!"
+    if "!PATH:~,1!"=="`" set "PATH=!PATH:~1,-1!"
     call :AddRegistryFavorite "!PATH!"
 )
 


### PR DESCRIPTION
## Summary
- ensure only table rows are parsed
- trim leading spaces and backticks from registry paths

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f53fde910832bbf0f09f69bcb83d6